### PR TITLE
Expand the response status header regex to reduce false positives

### DIFF
--- a/src/Logger/SimpleHttpLogger.php
+++ b/src/Logger/SimpleHttpLogger.php
@@ -71,6 +71,8 @@ class SimpleHttpLogger implements Logger
     protected function validResponse($headers)
     {
         foreach ($headers as $header) {
+            // We want to match the status header (e.g. "HTTP/1.1 202 Accepted") but not any other
+            // headers that might have the substring "202"
             if (preg_match('/^HTTP\/\S+\s+202/', $header)) {
                 return true;
             }

--- a/src/Logger/SimpleHttpLogger.php
+++ b/src/Logger/SimpleHttpLogger.php
@@ -71,7 +71,7 @@ class SimpleHttpLogger implements Logger
     protected function validResponse($headers)
     {
         foreach ($headers as $header) {
-            if (preg_match('/202/', $header)) {
+            if (preg_match('/^HTTP\/\S+\s+202/', $header)) {
                 return true;
             }
         }


### PR DESCRIPTION
Currently it can match something like "Date: Wed, 17 Feb 2021 18:52:55 GMT", so
we anchor it to start with "HTTP/&lt;non-whitespace&gt;&lt;whitespace&gt;202" to reduce that
possibility.

This isn't a perfect fix as I imagine the implementation for parsing the status
code in other frameworks, in other languages, is more robust. However PHP has
nothing along these lines in the standard library as far as I found find, so
this seemed like a decent compromise.